### PR TITLE
Use BSMT `OutputCopy` for Copying Related Files to Destinations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,65 +27,28 @@ jobs:
               uses: Goobwabber/download-beatmods-deps@1.3
               with:
                   manifest: ${{ github.workspace }}/BeatSaberSDK/manifest.json
-            - name: Generate BeatSaberDir override (.csproj.user)
-              shell: pwsh
-              run: |
-                # Path to the project file (adjust if the name or folder changes)
-                $projPath = "$Env:GITHUB_WORKSPACE\BeatSaberSDK\BeatSaberSDK.csproj"
-                $userFile = "$projPath.user"
-
-                # Compute the absolute path to Refs
-                $refsPath = [IO.Path]::GetFullPath((Join-Path $Env:GITHUB_WORKSPACE 'Refs'))
-
-                @"
-                <Project>
-                  <PropertyGroup>
-                    <BeatSaberDir>$refsPath</BeatSaberDir>
-                  </PropertyGroup>
-                </Project>
-                "@ | Out-File -FilePath $userFile -Encoding utf8 -Force
-
-                    Write-Host "Created $userFile with BeatSaberDir = $refsPath"
             - name: Build
               id: Build
               run: dotnet build --configuration Release
-            - name: GitStatus
-              run: git status
-            - name: Package output as zip (Libs\ & Plugins\)
-              id: package
-              shell: pwsh
-              run: |
-                $buildDir   = "$Env:GITHUB_WORKSPACE\BeatSaberSDK\bin\Release\net48"
-                $packageDir = "$Env:GITHUB_WORKSPACE\package"
-                $libsDir    = Join-Path $packageDir 'Libs'
-                $pluginsDir = Join-Path $packageDir 'Plugins'
-
-                New-Item $libsDir    -ItemType Directory -Force | Out-Null
-                New-Item $pluginsDir -ItemType Directory -Force | Out-Null
-
-                Copy-Item "$buildDir\Reactive.Components.dll"            $libsDir
-                Copy-Item "$buildDir\Reactive.dll"                        $libsDir
-                Copy-Item "$buildDir\Reactive.BeatSaber.Components.dll"   $pluginsDir
-                Copy-Item "$buildDir\Reactive.BeatSaber.Components.pdb"   $pluginsDir
-                Copy-Item "$buildDir\Reactive.Components.pdb"             $pluginsDir
-                Copy-Item "$buildDir\Reactive.pdb"                        $pluginsDir
-
-                $zipPath   = "$Env:GITHUB_WORKSPACE\beat-saber-sdk.zip"
-                Compress-Archive -Path "$packageDir\*" -DestinationPath $zipPath -Force
-
-                "zipfile=$zipPath"    | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
-                "packagedir=$packageDir" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+              env:
+                BeatSaberDir: ${{ github.workspace }}/Refs/
 
             - name: Upload Artifact
               uses: actions/upload-artifact@v4
               with:
-                name: beat-saber-sdk
-                path: ${{ steps.package.outputs.packagedir }}
+                name: ${{ steps.Build.outputs.filename }}
+                path: ${{ steps.Build.outputs.artifactpath }}
+
+            - name: Zip Artifact for Release
+              run: Compress-Archive -Path "${{ steps.Build.outputs.artifactpath }}\*" -DestinationPath "./${{ steps.Build.outputs.filename }}.zip"
+              if: startsWith(github.ref, 'refs/tags/')
 
             - name: Release
               uses: softprops/action-gh-release@v1
               if: startsWith(github.ref, 'refs/tags/')
               with:
-                files: ${{ steps.package.outputs.zipfile }}
+                draft: true
+                generate_release_notes: true
+                files: ./${{ steps.Build.outputs.filename }}.zip
               env:
                 GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,16 +39,17 @@ jobs:
                 name: ${{ steps.Build.outputs.filename }}
                 path: ${{ steps.Build.outputs.artifactpath }}
 
-            - name: Zip Artifact for Release
-              run: Compress-Archive -Path "${{ steps.Build.outputs.artifactpath }}\*" -DestinationPath "./${{ steps.Build.outputs.filename }}.zip"
-              if: startsWith(github.ref, 'refs/tags/')
-
-            - name: Release
-              uses: softprops/action-gh-release@v1
-              if: startsWith(github.ref, 'refs/tags/')
-              with:
-                draft: true
-                generate_release_notes: true
-                files: ./${{ steps.Build.outputs.filename }}.zip
-              env:
-                GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+#           Temporarily disable creating releases until we have a proper way to include yoga.dll
+#            - name: Zip Artifact for Release
+#              run: Compress-Archive -Path "${{ steps.Build.outputs.artifactpath }}\*" -DestinationPath "./${{ steps.Build.outputs.filename }}.zip"
+#              if: startsWith(github.ref, 'refs/tags/')
+#
+#            - name: Release
+#              uses: softprops/action-gh-release@v1
+#              if: startsWith(github.ref, 'refs/tags/')
+#              with:
+#                draft: true
+#                generate_release_notes: true
+#                files: ./${{ steps.Build.outputs.filename }}.zip
+#              env:
+#                GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/BeatSaberSDK/BeatSaberSDK.csproj
+++ b/BeatSaberSDK/BeatSaberSDK.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>net48</TargetFramework>
         <OutputType>Library</OutputType>
         <LocalRefsDir Condition="Exists('..\Refs')">..\Refs</LocalRefsDir>
-        <BeatSaberDir>$(LocalRefsDir)</BeatSaberDir>
+        <BeatSaberDir Condition="'$(BeatSaberDir)' == ''">$(LocalRefsDir)</BeatSaberDir>
         <AppOutputBase>$(MSBuildProjectDirectory)\</AppOutputBase>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
@@ -19,6 +19,9 @@
     </PropertyGroup>
 
     <Import Project="$(MSBuildProjectFile).user" Condition="Exists('$(MSBuildProjectFile).user')"/>
+    <ItemGroup>
+        <None Include="$(MSBuildProjectFile).user" Condition="Exists('$(MSBuildProjectFile).user')"/>
+    </ItemGroup>
     <PropertyGroup>
         <UnityAssembliesDir Condition="'$(UnityAssembliesDir)' == ''">$(BeatSaberDir)\Beat Saber_Data\Managed</UnityAssembliesDir>
     </PropertyGroup>
@@ -81,26 +84,6 @@
         <EmbeddedResource Include="Resources\AssetBundles\asset_bundle"/>
         <EmbeddedResource Include="manifest.json"/>
     </ItemGroup>
-
-    <!-- Post-processing -->
-    <PropertyGroup>
-        <ArtifactsDest>$(BeatSaberDir)\Plugins</ArtifactsDest>
-        <LibArtifactsDest>$(BeatSaberDir)\Libs</LibArtifactsDest>
-        <ArtifactFile>bin\$(Configuration)\net48\Reactive</ArtifactFile>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <Artifacts Include="$(ArtifactFile).BeatSaber.Components.dll;$(ArtifactFile).BeatSaber.Components.pdb"/>
-        <LibArtifacts Include="$(ArtifactFile).Components.dll;$(ArtifactFile).Components.pdb;$(ArtifactFile).dll;$(ArtifactFile).pdb"/>
-    </ItemGroup>
-
-    <Target Condition="$(CopyArtifacts) == True" Name="CopyArtifacts" AfterTargets="Build">
-        <Message Importance="high" Text="Copying artifacts:
-    BeatSaberSDK to $(ArtifactsDest)
-    Libs to $(LibArtifactsDest)"/>
-        <Copy SourceFiles="@(Artifacts)" DestinationFolder="$(ArtifactsDest)"/>
-        <Copy SourceFiles="@(LibArtifacts)" DestinationFolder="$(LibArtifactsDest)"/>
-    </Target>
 
     <ItemGroup>
         <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.2">

--- a/BeatSaberSDK/Directory.Build.props
+++ b/BeatSaberSDK/Directory.Build.props
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+        <!-- This file contains project properties used by the build. -->
+<Project>
+    <PropertyGroup>
+        <BSMTProjectType>BSIPA</BSMTProjectType>
+        <GenerateManifest>false</GenerateManifest>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <OutputCopy Include="$(OutputPath)\Reactive.dll" OutputPath="Libs\Reactive.dll" />
+        <OutputCopy Include="$(OutputPath)\Reactive.pdb" OutputPath="Libs\Reactive.pdb" />
+        <OutputCopy Include="$(OutputPath)\Reactive.Components.dll" OutputPath="Libs\Reactive.Components.dll" />
+        <OutputCopy Include="$(OutputPath)\Reactive.Components.pdb" OutputPath="Libs\Reactive.Components.pdb" />
+        <OutputCopy Include="$(OutputPath)\$(TargetFileName)" OutputPath="Plugins\$(TargetFileName)" />
+        <OutputCopy Include="$(OutputPath)\$(TargetName).pdb" OutputPath="Plugins\$(TargetName).pdb" />
+    </ItemGroup>
+</Project>


### PR DESCRIPTION
BSMT supports customizing the output files being copied into destination folders. We can use this feature to include all the related files in the artifact without copying files ourselves.

Please ignore the change to the cs file. It is to make the project compilable so I can test CI. The submodule is referencing an outdated commit, which doesn't have the latest API changes. I will drop this commit when we want to merge.

Known issue: the native yoga.dll is not included at the moment because it is not involved in the build process at all. This needs to be fixed before we can use CI to create releases. 

I also have some ideas for potential improvements I can add if you want:
- Include all related files in the `files` array of the manifest, or create a manifest file for the lib dlls and declare it as a dependency
- Create a manifest for the yoga.dll and declare it as a dependency after I figure out how to include yoga.dll in the archive
- ~~Incorporate the changes in the `embedded` branch~~

Not sure exactly how we are going to submit this library to BeatMods, so which files are going to be declared by which manifest(s) still needs to be decided.

